### PR TITLE
chore: enable Renovate security updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,7 +32,7 @@
       "matchJsonata": [
         "$exists(vulnerabilityFixVersion)"
       ],
-      "labels": [
+      "addLabels": [
         "security"
       ],
       "automerge": false
@@ -40,7 +40,7 @@
   ],
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
-    "labels": [
+    "addLabels": [
       "security"
     ],
     "automerge": false,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,7 +35,7 @@
       "addLabels": [
         "security"
       ],
-      "automerge": false
+      "automerge": true
     }
   ],
   "osvVulnerabilityAlerts": true,
@@ -43,7 +43,7 @@
     "addLabels": [
       "security"
     ],
-    "automerge": false,
+    "automerge": true,
     "vulnerabilityFixStrategy": "lowest"
   }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,49 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "helpers:pinGitHubActionDigests", "group:allNonMajor"],
-  "labels": ["Meta: Dependencies"],
-  "schedule": ["before 12pm on Sunday"],
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    "group:allNonMajor",
+    ":enableVulnerabilityAlerts"
+  ],
+  "labels": [
+    "Meta: Dependencies"
+  ],
+  "schedule": [
+    "before 12pm on Sunday"
+  ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
       "automerge": true
+    },
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false
+    },
+    {
+      "matchJsonata": [
+        "$exists(vulnerabilityFixVersion)"
+      ],
+      "labels": [
+        "security"
+      ],
+      "automerge": false
     }
-  ]
+  ],
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "labels": [
+      "security"
+    ],
+    "automerge": false,
+    "vulnerabilityFixStrategy": "lowest"
+  }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,21 +27,6 @@
         "major"
       ],
       "automerge": false
-    },
-    {
-      "matchJsonata": [
-        "isVulnerabilityAlert = true"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "pin",
-        "digest"
-      ],
-      "addLabels": [
-        "security"
-      ],
-      "automerge": true
     }
   ],
   "osvVulnerabilityAlerts": true,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,7 +30,13 @@
     },
     {
       "matchJsonata": [
-        "$exists(vulnerabilityFixVersion)"
+        "isVulnerabilityAlert = true"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
       ],
       "addLabels": [
         "security"
@@ -43,7 +49,6 @@
     "addLabels": [
       "security"
     ],
-    "automerge": true,
     "vulnerabilityFixStrategy": "lowest"
   }
 }


### PR DESCRIPTION
## Summary

- Enables Renovate vulnerability-alert PRs sourced from GitHub Dependabot alerts.
- Enables OSV scanning as a supplemental source for supported direct dependencies.
- Labels vulnerability-fix PRs `security` and enables automerge for them after CI succeeds.
- Prefers the lowest patched version to minimize compatibility risk.
- Explicitly disables automerge for major updates.
- Preserves the repository's existing Renovate rules; deprecated `config:base` references are migrated to `config:recommended` where present.

## Validation

- JSON parsing passed.
- `renovate-config-validator` from Renovate 43.275.0 passed.
- `git diff --check` passed.
- This is configuration-only; repository code and dependency lockfiles are unchanged.

## Security sources

- **Primary advisory source:** GitHub Dependabot alerts (Renovate reads alerts; Dependabot alerts remain open).
- **Supplemental source:** OSV via `osvVulnerabilityAlerts` (supported direct dependencies only).

## Manual follow-up

- Renovate is already active in this repository. Confirm the Renovate App installation now lists **Dependabot alerts: read**; GitHub does not expose that installation permission through the current `gh` OAuth token.
- After the next Renovate run, verify that vulnerability PRs carry the `security` label and automerge after CI succeeds.
- Do not enable duplicate Dependabot security-update PR generation once Renovate security PR creation is proven. Existing Dependabot security updates were not disabled in this change to avoid a coverage gap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Renovate security‑update PRs from GitHub Dependabot alerts and OSV, and migrates to `config:recommended`. Previously, security fixes were not created or auto‑merged; now Renovate opens `security`‑labeled PRs, prefers the lowest patched version, auto‑merges non‑major after CI, and keeps majors manual.

- Extends with `:enableVulnerabilityAlerts`; sets `osvVulnerabilityAlerts: true`.
- Adds `vulnerabilityAlerts.addLabels: ["security"]` and `vulnerabilityFixStrategy: "lowest"`.
- Auto‑merges `minor`/`patch`/`pin`/`digest` updates; disables automerge for `major` (no security‑specific rule).
- Migrates from `config:base` to `config:recommended`; preserves existing labels and schedule.
- Configuration only; no code or lockfile changes.

<sup>Written for commit cbb3cd93e66291f00332ee253119040ea5ba678c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TurboCheetah/succubus.space-api/pull/409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

